### PR TITLE
Add class diagram for freeTime

### DIFF
--- a/docs/diagrams/Dormie.puml
+++ b/docs/diagrams/Dormie.puml
@@ -74,7 +74,14 @@ class Person {
 +equals(Object): boolean
 }
 
-AddressBook "1" *-- "many" Person : contains
+class FreeTime {
+-day: String
+-startTime: String
+-endTime: String
+}
+
+AddressBook "1" *-- "*" Person : contains
+Person "1" *-- "*" FreeTime
 
 
 @enduml


### PR DESCRIPTION
### `Dormie.puml`

Noted that the `FreeTime` class is actually not created yet, it will be implemented for Milestone 1.3. Hence, changes may need to be done to update the UML diagram when the class is actually implemented.

For now, we expect the class to have three fields: 
`day`: A string or an enumeration value that represents the day. Some possible values will be MON (representing Monday), TUE (representing Tuesday), ..., SUN (representing Sunday).
`startTime`: A string or special class representing the start of free time.
`endTime`: A string or special class representing the end of free time.

A `Person` object can contain any number of `FreeTime` object, and it should be a whole-part relationship as the `FreeTime` cannot standalone without the `Person` object it belongs to.