### PR TITLE
Add free time tag

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -56,6 +56,11 @@ public class Messages {
             builder.append("; Birthday: ").append(person.getBirthday());
         }
 
+        if (!person.getTags().isEmpty()) {
+            builder.append("; Free Time Tags: ");
+            person.getTags().forEach(builder::append);
+        }
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -29,13 +30,15 @@ public class AddCommand extends Command {
             + PREFIX_ROOMNUMBER + "ROOM NUMBER "
             + PREFIX_TELEGRAM + "TELEGRAM "
             + PREFIX_BIRTHDAY + "BIRTHDAY "
+            + "[" + PREFIX_FREETIMETAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ROOMNUMBER + "sw-01-01 "
             + PREFIX_TELEGRAM + "johnDoe "
-            + PREFIX_BIRTHDAY + "12/12/2000 ";
+            + PREFIX_BIRTHDAY + "12/12/2000 "
+            + PREFIX_FREETIMETAG + "Mon:1pm-2pm";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -3,11 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,14 +3,19 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,11 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -26,6 +25,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
 
 /**
  * Edits the details of an existing person in the address book.
@@ -44,6 +44,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_ROOMNUMBER + "ROOM NUMBER] "
             + "[" + PREFIX_TELEGRAM + "TELEGRAM] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
+            + "[" + PREFIX_FREETIMETAG + "FREE TIME]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -101,9 +102,10 @@ public class EditCommand extends Command {
         RoomNumber updatedRoomNumber = editPersonDescriptor.getRoomNumber().orElse(personToEdit.getRoomNumber());
         Telegram updatedTelegram = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
         Birthday updatedBirthday = editPersonDescriptor.getBirthday().orElse(personToEdit.getBirthday());
+        Set<FreeTimeTag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedRoomNumber, updatedTelegram,
-                updatedBirthday);
+                updatedBirthday, updatedTags);
     }
 
     @Override
@@ -141,11 +143,12 @@ public class EditCommand extends Command {
         private RoomNumber roomNumber;
         private Telegram telegram;
         private Birthday birthday;
-
+        private Set<FreeTimeTag> tags;
         public EditPersonDescriptor() {}
 
         /**
          * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
             setName(toCopy.name);
@@ -154,13 +157,14 @@ public class EditCommand extends Command {
             setRoomNumber(toCopy.roomNumber);
             setTelegram(toCopy.telegram);
             setBirthday(toCopy.birthday);
+            setTags(toCopy.tags);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, roomNumber, telegram, birthday);
+            return CollectionUtil.isAnyNonNull(name, phone, email, roomNumber, telegram, birthday, tags);
         }
 
         public void setName(Name name) {
@@ -211,6 +215,22 @@ public class EditCommand extends Command {
             return Optional.ofNullable(birthday);
         }
 
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<FreeTimeTag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<FreeTimeTag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
 
         @Override
         public boolean equals(Object other) {
@@ -229,7 +249,8 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(roomNumber, otherEditPersonDescriptor.roomNumber)
                     && Objects.equals(telegram, otherEditPersonDescriptor.telegram)
-                    && Objects.equals(birthday, otherEditPersonDescriptor.birthday);
+                    && Objects.equals(birthday, otherEditPersonDescriptor.birthday)
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
         @Override
@@ -241,6 +262,7 @@ public class EditCommand extends Command {
                     .add("roomNumber", roomNumber)
                     .add("telegram", telegram)
                     .add("birthday", birthday)
+                    .add("freeTimeTags", tags)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,14 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -20,6 +16,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -35,7 +32,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
-                        PREFIX_TELEGRAM, PREFIX_BIRTHDAY);
+                        PREFIX_TELEGRAM, PREFIX_BIRTHDAY, PREFIX_FREETIMETAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -62,7 +59,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Optional<String> birthdayText = argMultimap.getValue(PREFIX_BIRTHDAY);
         Birthday birthday = birthdayText.isPresent() ? ParserUtil.parseBirthday(birthdayText.get()) : null;
 
-        Person person = new Person(name, phone, email, roomNumber, telegram, birthday);
+        Optional<String> freeTimeTagText = argMultimap.getValue(PREFIX_FREETIMETAG);
+        Set<FreeTimeTag> freeTimeTags = freeTimeTagText.isPresent() ? ParserUtil.parseFreeTimeTags(argMultimap.getAllValues(PREFIX_FREETIMETAG)) : null;
+
+        Person person = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTags);
         return new AddCommand(person);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,7 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Optional;
 import java.util.Set;
@@ -60,7 +66,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         Birthday birthday = birthdayText.isPresent() ? ParserUtil.parseBirthday(birthdayText.get()) : null;
 
         Optional<String> freeTimeTagText = argMultimap.getValue(PREFIX_FREETIMETAG);
-        Set<FreeTimeTag> freeTimeTags = freeTimeTagText.isPresent() ? ParserUtil.parseFreeTimeTags(argMultimap.getAllValues(PREFIX_FREETIMETAG)) : null;
+        Set<FreeTimeTag> freeTimeTags = freeTimeTagText.isPresent()
+                ? ParserUtil.parseFreeTimeTags(argMultimap.getAllValues(PREFIX_FREETIMETAG)) : null;
 
         Person person = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTags);
         return new AddCommand(person);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_ROOMNUMBER = new Prefix("r/");
     public static final Prefix PREFIX_TELEGRAM = new Prefix("t/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
-
+    public static final Prefix PREFIX_FREETIMETAG = new Prefix("ft/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,7 +2,18 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
@@ -10,10 +21,6 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.FreeTimeTag;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Parses input arguments and creates a new EditCommand object

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,17 +2,18 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.FreeTimeTag;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -28,7 +29,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
-                        PREFIX_TELEGRAM, PREFIX_BIRTHDAY);
+                        PREFIX_TELEGRAM, PREFIX_BIRTHDAY, PREFIX_FREETIMETAG);
 
         Index index;
 
@@ -39,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
-                PREFIX_TELEGRAM, PREFIX_BIRTHDAY);
+                PREFIX_TELEGRAM, PREFIX_BIRTHDAY, PREFIX_FREETIMETAG);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -63,11 +64,28 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY).get()));
         }
 
+        parseFreeTimeTagsForEdit(argMultimap.getAllValues(PREFIX_FREETIMETAG)).ifPresent(editPersonDescriptor::setTags);
+
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
         return new EditCommand(index, editPersonDescriptor);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<FreeTimeTag>> parseFreeTimeTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseFreeTimeTags(tagSet));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -40,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
-                PREFIX_TELEGRAM, PREFIX_BIRTHDAY, PREFIX_FREETIMETAG);
+                PREFIX_TELEGRAM, PREFIX_BIRTHDAY);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -11,12 +15,9 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
-import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.FreeTimeTag;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -11,6 +11,12 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.FreeTimeTag;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -120,5 +126,32 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String tag} into a {@code Tag}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code tag} is invalid.
+     */
+    public static FreeTimeTag parseFreeTimeTag(String tag) throws ParseException {
+        requireNonNull(tag);
+        String trimmedTag = tag.trim();
+        if (!FreeTimeTag.isValidTagName(trimmedTag)) {
+            throw new ParseException(FreeTimeTag.MESSAGE_CONSTRAINTS);
+        }
+        return new FreeTimeTag(trimmedTag);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     */
+    public static Set<FreeTimeTag> parseFreeTimeTags(Collection<String> tags) throws ParseException {
+        requireNonNull(tags);
+        final Set<FreeTimeTag> tagSet = new HashSet<>();
+        for (String tagName : tags) {
+            tagSet.add(parseFreeTimeTag(tagName));
+        }
+        return tagSet;
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,9 +2,14 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.FreeTimeTag;
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Person in the logbook.
@@ -21,11 +26,11 @@ public class Person {
     private final RoomNumber roomNumber;
     private final Telegram telegram;
     private final Birthday birthday;
-
+    private final Set<FreeTimeTag> tags = new HashSet<>();
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber, Telegram telegram, Birthday birthday) {
+    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber, Telegram telegram, Birthday birthday, Set<FreeTimeTag> tags) {
         requireAllNonNull(name, phone);
         this.name = name;
         this.phone = phone;
@@ -33,6 +38,7 @@ public class Person {
         this.roomNumber = roomNumber;
         this.telegram = telegram;
         this.birthday = birthday;
+        this.tags.addAll(tags);
     }
 
     public Name getName() {
@@ -59,6 +65,13 @@ public class Person {
         return birthday;
     }
 
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<FreeTimeTag> getTags() {
+        return Collections.unmodifiableSet(tags);
+    }
 
     /**
      * Returns true if both persons have the same name.
@@ -117,13 +130,15 @@ public class Person {
             isEqual = isEqual && birthday.equals(otherPerson.birthday);
         }
 
+        isEqual = isEqual && tags.equals(otherPerson.tags);
+
         return isEqual;
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, roomNumber, telegram, birthday);
+        return Objects.hash(name, phone, email, roomNumber, telegram, birthday, tags);
     }
 
     @Override
@@ -131,6 +146,7 @@ public class Person {
         ToStringBuilder sb = new ToStringBuilder(this);
         sb.add("name", name);
         sb.add("phone", phone);
+        sb.add("tags", tags);
 
         if (email != null) {
             sb.add("email", email);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.FreeTimeTag;
-import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Person in the logbook.
@@ -30,7 +29,8 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber, Telegram telegram, Birthday birthday, Set<FreeTimeTag> tags) {
+    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber, Telegram telegram, Birthday birthday,
+                  Set<FreeTimeTag> tags) {
         requireAllNonNull(name, phone);
         this.name = name;
         this.phone = phone;

--- a/src/main/java/seedu/address/model/tag/FreeTimeTag.java
+++ b/src/main/java/seedu/address/model/tag/FreeTimeTag.java
@@ -2,6 +2,9 @@ package seedu.address.model.tag;
 
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+/**
+ * Represents a Free Time Tag in Dormie.
+ */
 public class FreeTimeTag extends Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Free Time Tag should be Mon-Sun:HHmm-HHmm (24hr format)";
@@ -24,6 +27,8 @@ public class FreeTimeTag extends Tag {
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/model/tag/FreeTimeTag.java
+++ b/src/main/java/seedu/address/model/tag/FreeTimeTag.java
@@ -1,0 +1,51 @@
+package seedu.address.model.tag;
+
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class FreeTimeTag extends Tag {
+
+    public static final String MESSAGE_CONSTRAINTS = "Free Time Tag should be Mon-Sun:HHmm-HHmm (24hr format)";
+    public static final String VALIDATION_REGEX =
+            "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(0[0-9]|1[0-9]|2[0-3])([0-5][0-9])-(0[0-9]|1[0-9]|2[0-3])([0-5][0-9])$";
+
+    /**
+     * Constructs a {@code FreeTimeTag}.
+     *
+     * @param tagName A valid tag name.
+     */
+    public FreeTimeTag(String tagName) {
+        super(tagName);
+        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Returns true if a given string is a valid tag name.
+     */
+    public static boolean isValidTagName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Tag)) {
+            return false;
+        }
+
+        Tag otherTag = (Tag) other;
+        return tagName.equals(otherTag.tagName);
+    }
+
+    public int hashCode() {
+        return tagName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + tagName + ']';
+    }
+}

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,0 +1,31 @@
+package seedu.address.model.tag;
+
+import static java.util.Objects.requireNonNull;
+/**
+ *  Represents a Tag in Dormie.
+ */
+public abstract class Tag {
+    public static final String MESSAGE_CONSTRAINTS = "Tag is in the wrong format";
+    public final String tagName;
+
+    /**
+     * Constructs a Tag.
+     *
+     * @param tagName the name of the tag
+     */
+    public Tag(String tagName) {
+        requireNonNull(tagName);
+        this.tagName = tagName;
+    }
+
+    @Override
+    public abstract boolean equals(Object other);
+
+    @Override
+    public abstract int hashCode();
+
+    /**
+     * Format state of Tag object for viewing.
+     */
+    public abstract String toString();
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,5 +1,9 @@
 package seedu.address.model.util;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Birthday;
@@ -10,11 +14,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
 import seedu.address.model.tag.FreeTimeTag;
-import seedu.address.model.tag.Tag;
-
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,12 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
+import seedu.address.model.tag.Tag;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
@@ -17,17 +23,11 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new RoomNumber("21-06-40"), new Telegram("alexYeoh"), new Birthday("03/02/2000")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new RoomNumber("21-07-18"), new Telegram("berniceYu"), new Birthday("21/02/1999")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new RoomNumber("21-11-04"), new Telegram("charlotteOliveiro"), new Birthday("02/04/2000")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new RoomNumber("21-16-43"), new Telegram("davidLi"), new Birthday("21/04/1998")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new RoomNumber("21-17-35"), new Telegram("irfanIbrahim"), new Birthday("16/04/1993")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new RoomNumber("21-11-31"), new Telegram("royBalakrishnan"), new Birthday("18/09/1992"))
+                new RoomNumber("21-06-40"), new Telegram("alexYeoh"), new Birthday("03/02/2000"),
+                    getTagSet("Mon:1300-1400")),
+            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@gmail"),
+                new RoomNumber("21-06-40"), new Telegram("berniceYu"), new Birthday("03/02/2000"),
+                    getTagSet("Tue:0700-2100"))
         };
     }
 
@@ -39,4 +39,12 @@ public class SampleDataUtil {
         return sampleAb;
     }
 
+    /**
+     * Returns a tag set containing the list of strings given.
+     */
+    public static Set<FreeTimeTag> getTagSet(String... strings) {
+        return Arrays.stream(strings)
+                .map(FreeTimeTag::new)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.FreeTimeTag;
 import seedu.address.model.tag.Tag;

--- a/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
@@ -1,0 +1,48 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.tag.FreeTimeTag;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Tag}.
+ */
+class JsonAdaptedFreeTimeTag {
+
+    private final String freeTimeTagName;
+
+    /**
+     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     */
+    @JsonCreator
+    public JsonAdaptedFreeTimeTag(String freeTimeTagName) {
+        this.freeTimeTagName = freeTimeTagName;
+    }
+
+    /**
+     * Converts a given {@code Tag} into this class for Jackson use.
+     */
+    public JsonAdaptedFreeTimeTag(FreeTimeTag source) {
+        freeTimeTagName = source.tagName;
+    }
+
+    @JsonValue
+    public String getTagName() {
+        return freeTimeTagName;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public FreeTimeTag toModelType() throws IllegalValueException {
+        if (!FreeTimeTag.isValidTagName(freeTimeTagName)) {
+            throw new IllegalValueException(FreeTimeTag.MESSAGE_CONSTRAINTS);
+        }
+        return new FreeTimeTag(freeTimeTagName);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -11,6 +11,14 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
+import seedu.address.model.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Jackson-friendly version of {@link Person}.
@@ -25,20 +33,24 @@ class JsonAdaptedPerson {
     private final String roomNumber;
     private final String telegram;
     private final String birthday;
-
+    private final List<JsonAdaptedFreeTimeTag> freeTimeTags = new ArrayList<>();
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("roomNumber") String roomNumber,
-                             @JsonProperty("telegram") String telegram, @JsonProperty("birthday") String birthday) {
+                             @JsonProperty("telegram") String telegram, @JsonProperty("birthday") String birthday,
+                             @JsonProperty("tags") List<JsonAdaptedFreeTimeTag> freeTimeTags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.roomNumber = roomNumber;
         this.telegram = telegram;
         this.birthday = birthday;
+        if (freeTimeTags != null) {
+            this.freeTimeTags.addAll(freeTimeTags);
+        }
     }
 
     /**
@@ -51,6 +63,9 @@ class JsonAdaptedPerson {
         roomNumber = source.getRoomNumber() == null ? null : source.getRoomNumber().toString();
         telegram = source.getTelegram() == null ? null : source.getTelegram().value;
         birthday = source.getBirthday() == null ? null : String.valueOf(source.getBirthday().value);
+        freeTimeTags.addAll(source.getTags().stream()
+                .map(JsonAdaptedFreeTimeTag::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -59,6 +74,10 @@ class JsonAdaptedPerson {
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
     public Person toModelType() throws IllegalValueException {
+        final List<FreeTimeTag> freeTimeTagList = new ArrayList<>();
+        for (JsonAdaptedFreeTimeTag freeTimeTag : freeTimeTags) {
+            freeTimeTagList.add(freeTimeTag.toModelType());
+        }
 
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -111,7 +130,9 @@ class JsonAdaptedPerson {
         }
         final Birthday modelBirthday = new Birthday(birthday);
 
-        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelTelegram, modelBirthday);
+        final Set<FreeTimeTag> modelFreeTimeTags = new HashSet<>(freeTimeTagList);
+
+        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelTelegram, modelBirthday, modelFreeTimeTags);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -1,5 +1,11 @@
 package seedu.address.storage;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -12,13 +18,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
 import seedu.address.model.tag.FreeTimeTag;
-import seedu.address.model.tag.Tag;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Jackson-friendly version of {@link Person}.
@@ -132,7 +131,8 @@ class JsonAdaptedPerson {
 
         final Set<FreeTimeTag> modelFreeTimeTags = new HashSet<>(freeTimeTagList);
 
-        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelTelegram, modelBirthday, modelFreeTimeTags);
+        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelTelegram, modelBirthday,
+                modelFreeTimeTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,10 +1,15 @@
 package seedu.address.ui;
 
+import java.util.Comparator;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
+
+
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -41,6 +46,8 @@ public class PersonCard extends UiPart<Region> {
     private Label birthday;
     @FXML
     private Label email;
+    @FXML
+    private FlowPane freeTimeTags;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to
@@ -57,5 +64,8 @@ public class PersonCard extends UiPart<Region> {
         telegram.setText(person.getTelegram() != null ? person.getTelegram().value : "");
         birthday.setText(person.getBirthday() != null ? String.valueOf(person.getBirthday()) : "");
         email.setText(person.getEmail() != null ? person.getEmail().value : "");
+        person.getTags().stream()
+                .sorted(Comparator.comparing(freeTag -> freeTag.tagName))
+                .forEach(freeTag -> freeTimeTags.getChildren().add(new Label(freeTag.tagName)));
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -337,12 +337,12 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#freeTimeTags {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#tags .label {
+#freeTimeTags .label {
     -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,7 +27,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="tags" />
+      <FlowPane fx:id="freeTimeTags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="roomNumber" styleClass="cell_small_label" text="\$roomNumber" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/java/seedu/address/logic/MessagesTest.java
+++ b/src/test/java/seedu/address/logic/MessagesTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.Birthday;
@@ -11,6 +13,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
 
 public class MessagesTest {
 
@@ -28,8 +31,9 @@ public class MessagesTest {
         RoomNumber roomNumber = new RoomNumber("sw-01-01");
         Telegram telegram = new Telegram("Johnny");
         Birthday birthday = new Birthday("01-01-2000");
+        Set<FreeTimeTag> freeTimeTag = Set.of(new FreeTimeTag("Sun:1000-1400"));
 
-        Person person = new Person(name, phone, email, roomNumber, telegram, birthday);
+        Person person = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTag);
         assertMessageSuccess(person, FORMATTED_ALL_FIELDS_MESSAGE);
     }
 
@@ -41,8 +45,9 @@ public class MessagesTest {
         RoomNumber roomNumber = null;
         Telegram telegram = null;
         Birthday birthday = null;
+        Set<FreeTimeTag> freeTimeTag = Set.of(new FreeTimeTag("Sun:1000-1400"));
 
-        Person person = new Person(name, phone, email, roomNumber, telegram, birthday);
+        Person person = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTag);
         assertMessageSuccess(person, FORMATTED_ALL_MANDATORY_FIELDS_MESSAGE);
     }
 
@@ -54,8 +59,9 @@ public class MessagesTest {
         RoomNumber roomNumber = new RoomNumber("sw-01-01");
         Telegram telegram = null;
         Birthday birthday = new Birthday("01-01-2000");
+        Set<FreeTimeTag> freeTimeTag = Set.of(new FreeTimeTag("Sun:1000-1400"));
 
-        Person person = new Person(name, phone, email, roomNumber, telegram, birthday);
+        Person person = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTag);
         assertMessageSuccess(person, FORMATTED_ALL_MANDATORY_AND_SOME_OPTIONAL_FIELDS_MESSAGE);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREETIMETAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
@@ -39,6 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_TELEGRAM_BOB = "bobChoo";
     public static final String VALID_BIRTHDAY_AMY = "01/01/2000";
     public static final String VALID_BIRTHDAY_BOB = "02/02/2000";
+    public static final String VALID_FREE_TIME_TAG_AMY = "Mon:1000-1200";
+    public static final String VALID_FREE_TIME_TAG_BOB = "Wed:1400-2000";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -52,6 +55,8 @@ public class CommandTestUtil {
     public static final String TELEGRAM_DESC_BOB = " " + PREFIX_TELEGRAM + VALID_TELEGRAM_BOB;
     public static final String BIRTHDAY_DESC_AMY = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_AMY;
     public static final String BIRTHDAY_DESC_BOB = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_BOB;
+    public static final String FREE_TIME_TAG_DESC_AMY = " " + PREFIX_FREETIMETAG + VALID_FREE_TIME_TAG_AMY;
+    public static final String FREE_TIME_TAG_DESC_BOB = " " + PREFIX_FREETIMETAG + VALID_FREE_TIME_TAG_BOB;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -59,6 +64,8 @@ public class CommandTestUtil {
     public static final String INVALID_ROOMNUMBER_DESC = " " + PREFIX_ROOMNUMBER; // empty string not allowed for room
     public static final String INVALID_TELEGRAM_DESC = " " + PREFIX_TELEGRAM; // empty string not allowed for telegram
     public static final String INVALID_BIRTHDAY_DESC = " " + PREFIX_BIRTHDAY; // empty string not allowed for birthday
+    public static final String INVALID_FREE_TIME_TAG_DESC = " "
+            + PREFIX_FREETIMETAG; // empty string not allowed for free time tag
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -14,6 +14,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ROOMNUMBER_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
@@ -24,6 +26,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
@@ -46,8 +49,10 @@ public class AddCommandParserTest {
         RoomNumber roomNumber = new RoomNumber(VALID_ROOMNUMBER_BOB);
         Telegram telegram = null;
         Birthday birthday = new Birthday(VALID_BIRTHDAY_BOB);
+        Set<FreeTimeTag> freeTimeTag = Set.of(new FreeTimeTag("Sun:1000-1400"));
 
-        Person expectedPerson = new Person(name, phone, email, roomNumber, telegram, birthday);
+
+        Person expectedPerson = new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTag);
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -89,7 +89,8 @@ public class PersonTest {
                 null,
                 ALICE.getRoomNumber(),
                 ALICE.getTelegram(),
-                ALICE.getBirthday());
+                ALICE.getBirthday(),
+                ALICE.getTags());
         assertFalse(ALICE.equals(aliceCopyWithoutEmail));
         assertFalse(aliceCopyWithoutEmail.equals(ALICE));
 
@@ -99,7 +100,8 @@ public class PersonTest {
                 ALICE.getEmail(),
                 null,
                 ALICE.getTelegram(),
-                ALICE.getBirthday());
+                ALICE.getBirthday(),
+                ALICE.getTags());
         assertFalse(ALICE.equals(aliceCopyWithoutRoomNumber));
         assertFalse(aliceCopyWithoutRoomNumber.equals(ALICE));
 
@@ -109,7 +111,8 @@ public class PersonTest {
                 ALICE.getEmail(),
                 ALICE.getRoomNumber(),
                 null,
-                ALICE.getBirthday());
+                ALICE.getBirthday(),
+                ALICE.getTags());
         assertFalse(ALICE.equals(aliceCopyWithoutTelegram));
         assertFalse(aliceCopyWithoutTelegram.equals(ALICE));
 
@@ -119,7 +122,8 @@ public class PersonTest {
                 ALICE.getEmail(),
                 ALICE.getRoomNumber(),
                 ALICE.getTelegram(),
-                null);
+                null,
+                ALICE.getTags());
         assertFalse(ALICE.equals(aliceCopyWithoutBirthday));
         assertFalse(aliceCopyWithoutBirthday.equals(ALICE));
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -5,6 +5,10 @@ import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORM
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -22,6 +26,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_TELEGRAM = " ";
     private static final String INVALID_BIRTHDAY = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_FREETIMETAGS = "Mon:1pm-2pm";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -29,6 +34,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_ROOMNUMBER = BENSON.getRoomNumber().toString();
     private static final String VALID_TELEGRAM = BENSON.getTelegram().toString();
     private static final String VALID_BIRTHDAY = BENSON.getBirthday().toString();
+    private static final List<JsonAdaptedFreeTimeTag> VALID_FREETIMETAGS = BENSON.getTags().stream()
+            .map(JsonAdaptedFreeTimeTag::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -40,7 +48,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_TELEGRAM,
-                        VALID_BIRTHDAY);
+                        VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -48,7 +56,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER,
-                VALID_TELEGRAM, VALID_BIRTHDAY);
+                VALID_TELEGRAM, VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -57,7 +65,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_TELEGRAM,
-                        VALID_BIRTHDAY);
+                        VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,7 +73,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ROOMNUMBER,
-                VALID_TELEGRAM, VALID_BIRTHDAY);
+                VALID_TELEGRAM, VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +82,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROOMNUMBER, VALID_TELEGRAM,
-                        VALID_BIRTHDAY);
+                        VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +90,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ROOMNUMBER,
-                VALID_TELEGRAM, VALID_BIRTHDAY);
+                VALID_TELEGRAM, VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +99,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidRoomNumber_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROOMNUMBER, VALID_TELEGRAM,
-                        VALID_BIRTHDAY);
+                        VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = RoomNumber.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -99,7 +107,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullRoomNumber_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TELEGRAM, VALID_BIRTHDAY);
+                VALID_TELEGRAM, VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +116,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTelegram_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, INVALID_TELEGRAM,
-                        VALID_BIRTHDAY);
+                        VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = Telegram.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -116,7 +124,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullTelegram_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER,
-                null, VALID_BIRTHDAY);
+                null, VALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Telegram.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -125,7 +133,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidBirthday_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_TELEGRAM,
-                        INVALID_BIRTHDAY);
+                        INVALID_BIRTHDAY, VALID_FREETIMETAGS);
         String expectedMessage = Birthday.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -133,7 +141,26 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullBirthday_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER,
-                VALID_TELEGRAM, null);
+                VALID_TELEGRAM, null, VALID_FREETIMETAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Birthday.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidFreeTimeTags_throwsIllegalValueException() {
+        //unsure about the parseInt part
+        List<JsonAdaptedFreeTimeTag> invalidTags = new ArrayList<>(Integer.parseInt(INVALID_FREETIMETAGS));
+        invalidTags.add(new JsonAdaptedFreeTimeTag(INVALID_FREETIMETAGS));
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER,
+                VALID_TELEGRAM, VALID_BIRTHDAY, invalidTags);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Birthday.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullFreeTimeTags_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER,
+                VALID_TELEGRAM, VALID_BIRTHDAY, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Birthday.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,5 +1,8 @@
 package seedu.address.testutil;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -7,6 +10,8 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
+import seedu.address.model.util.SampleDataUtil;
 
 /**
  * A utility class to help with building Person objects.
@@ -26,6 +31,7 @@ public class PersonBuilder {
     private RoomNumber roomNumber;
     private Telegram telegram;
     private Birthday birthday;
+    private Set<FreeTimeTag> freeTimeTags;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -37,6 +43,7 @@ public class PersonBuilder {
         roomNumber = new RoomNumber(DEFAULT_ROOMNUMBER);
         telegram = new Telegram(DEFAULT_TELEGRAM);
         birthday = new Birthday(DEFAULT_BIRTHDAY);
+        freeTimeTags = new HashSet<>();
     }
 
     /**
@@ -49,6 +56,7 @@ public class PersonBuilder {
         roomNumber = personToCopy.getRoomNumber();
         telegram = personToCopy.getTelegram();
         birthday = personToCopy.getBirthday();
+        freeTimeTags = new HashSet<>(personToCopy.getTags());
     }
 
     /**
@@ -99,8 +107,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code FreeTimeTag} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withFreeTimeTags(String ... freeTime) {
+        this.freeTimeTags = SampleDataUtil.getTagSet(freeTime);
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, roomNumber, telegram, birthday);
+        return new Person(name, phone, email, roomNumber, telegram, birthday, freeTimeTags);
     }
 
 }


### PR DESCRIPTION
Added Free Time Tags

Format
- Prefix: ft/
- Mon-Sun:HHmm-HHmm (24hr format)
- Example: `add n/pallon p/91111111 e/a@a.com r/00-00-00 t/pallon b/11/11/1111 ft/Mon:1300-1400`
- Example: `edit [INDEX] ft/Mon:1300-1400 ft/Wed:1300-1400`

Notes:
- Supports multiple free time tags
- Added test cases for invalid and null free time tags