### PR TITLE
Add multi editing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -55,21 +56,36 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited person: %1$s";
+    public static final String MESSAGE_MULTIEDIT_FAIL = "%1$s cannot be edited for multiple persons at once.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
-    private final Index index;
+    private final Set<Index> indices;
     private final EditPersonDescriptor editPersonDescriptor;
+
+    /**
+     * @param indices of the person in the filtered person list to edit
+     * @param editPersonDescriptor details to edit the person with
+     */
+    public EditCommand(Set<Index> indices, EditPersonDescriptor editPersonDescriptor) {
+        requireNonNull(indices);
+        requireNonNull(editPersonDescriptor);
+
+        this.indices = indices;
+        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+    }
 
     /**
      * @param index of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
+
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
-        this.index = index;
+        this.indices = new HashSet<>();
+        this.indices.add(index);
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
 
@@ -77,21 +93,24 @@ public class EditCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        String res = "";
+        for (Index index : indices) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            Person personToEdit = lastShownList.get(index.getZeroBased());
+            Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+
+            if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            }
+
+            model.setPerson(personToEdit, editedPerson);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            res = String.format("%s %s", res, Messages.format(editedPerson));
         }
-
-        Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
-
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
-
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, res.trim()));
     }
 
     /**
@@ -125,14 +144,18 @@ public class EditCommand extends Command {
         }
 
         EditCommand otherEditCommand = (EditCommand) other;
-        return index.equals(otherEditCommand.index)
+        Object[] indicesArray = indices.toArray();
+        Object[] otherIndicesArray = otherEditCommand.indices.toArray();
+        Arrays.sort(indicesArray);
+        Arrays.sort(otherIndicesArray);
+        return Arrays.equals(indicesArray, otherIndicesArray)
                 && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("index", index)
+                .add("index", indices)
                 .add("editPersonDescriptor", editPersonDescriptor)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -15,7 +15,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -27,6 +29,7 @@ import seedu.address.model.tag.FreeTimeTag;
  * Parses input arguments and creates a new EditCommand object
  */
 public class EditCommandParser implements Parser<EditCommand> {
+    private static final Logger logger = LogsCenter.getLogger(EditCommandParser.class);
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -46,6 +49,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             for (String i : indices) {
                 index.add(ParserUtil.parseIndex(i.trim()));
             }
+            logger.info("Index parsed successfully");
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,10 +39,13 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
                         PREFIX_TELEGRAM, PREFIX_BIRTHDAY, PREFIX_FREETIMETAG);
 
-        Index index;
+        Set <Index> index = new HashSet<>();
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            String[] indices = argMultimap.getPreamble().trim().split("\\s+");
+            for (String i : indices) {
+                index.add(ParserUtil.parseIndex(i.trim()));
+            }
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
@@ -52,22 +56,40 @@ public class EditCommandParser implements Parser<EditCommand> {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "NAME"));
+            }
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "PHONE"));
+            }
             editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "EMAIL"));
+            }
             editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ROOMNUMBER).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "ROOM NUMBER"));
+            }
             editPersonDescriptor.setRoomNumber(ParserUtil.parseRoomNumber(argMultimap
                     .getValue(PREFIX_ROOMNUMBER).get()));
         }
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "TELEGRAM"));
+            }
             editPersonDescriptor.setTelegram(ParserUtil.parseTelegram(argMultimap.getValue(PREFIX_TELEGRAM).get()));
         }
         if (argMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
+            if (index.size() > 1) {
+                throw new ParseException(String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "BIRTHDAY"));
+            }
             editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY).get()));
         }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -14,6 +14,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -31,7 +33,6 @@ import seedu.address.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
-
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
@@ -174,7 +175,7 @@ public class EditCommandTest {
         Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
-        String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
+        String expected = EditCommand.class.getCanonicalName() + "{index=" + Set.of(index) + ", editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
@@ -14,6 +15,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.ROOMNUMBER_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ROOMNUMBER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TELEGRAM_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -179,5 +181,41 @@ public class EditCommandParserTest {
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER));
+    }
+    @Test
+    public void parse_multiplePersonEditName_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), NAME_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "NAME"));
+    }
+    @Test
+    public void parse_multiplePersonEditPhone_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), PHONE_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "PHONE"));
+    }
+    @Test
+    public void parse_multiplePersonEditEmail_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), EMAIL_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "EMAIL"));
+    }
+    @Test
+    public void parse_multiplePersonEditRoomNumber_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), ROOMNUMBER_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "ROOM NUMBER"));
+    }
+    @Test
+    public void parse_multiplePersonEditTelegram_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), TELEGRAM_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "TELEGRAM"));
+    }
+    @Test
+    public void parse_multiplePersonEditBirthday_failure() {
+        String userInput = String.format("%d %d %s", INDEX_FIRST_PERSON.getOneBased(),
+                INDEX_SECOND_PERSON.getOneBased(), BIRTHDAY_DESC_AMY);
+        assertParseFailure(parser, userInput, String.format(EditCommand.MESSAGE_MULTIEDIT_FAIL, "BIRTHDAY"));
     }
 }


### PR DESCRIPTION
* Changed `Index` to `Set<Index>`
* Multiple editing of fields other than free time is prohibited
* Added logger for the juicy tag
* Invalid edit indices
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/111074273/89371e2b-c807-470f-88f1-346e3994c2c7)
* Successfully edit multiple free time
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/111074273/56860982-3c0a-44ca-8563-f86dfe50e56e)
* Failed to multi-edit name
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/111074273/d78b6949-cf2a-4c16-bdd4-455f6509d47d)
* Successfully edit single person name
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/111074273/1a7085f9-641c-4375-9b3c-9b2a3e9c62bb)