### PR TITLE
Free time interval check

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -146,6 +146,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
+     * Also checks free time tag validity
      *
      * @throws ParseException if the given {@code tag} is invalid.
      */
@@ -154,6 +155,9 @@ public class ParserUtil {
         String trimmedTag = tag.trim();
         if (!FreeTimeTag.isValidTagName(trimmedTag)) {
             throw new ParseException(FreeTimeTag.MESSAGE_CONSTRAINTS);
+        }
+        if (!FreeTimeTag.isValidTimeInterval(trimmedTag)) {
+            throw new ParseException(FreeTimeTag.MESSAGE_INVALID_TIME_INTERVAL);
         }
         return new FreeTimeTag(trimmedTag);
     }

--- a/src/main/java/seedu/address/model/tag/FreeTimeTag.java
+++ b/src/main/java/seedu/address/model/tag/FreeTimeTag.java
@@ -9,6 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class FreeTimeTag extends Tag implements Comparable<FreeTimeTag> {
 
     public static final String MESSAGE_CONSTRAINTS = "Free Time Tag should be Mon-Sun:HHmm-HHmm (24hr format)";
+
+    public static final String MESSAGE_INVALID_TIME_INTERVAL = "Start time should be earlier than End time";
     public static final String VALIDATION_REGEX =
             "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(0[0-9]|1[0-9]|2[0-3])([0-5][0-9])-(0[0-9]|1[0-9]|2[0-3])([0-5][0-9])$";
 
@@ -20,8 +22,23 @@ public class FreeTimeTag extends Tag implements Comparable<FreeTimeTag> {
     public FreeTimeTag(String tagName) {
         super(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidTimeInterval(tagName), MESSAGE_INVALID_TIME_INTERVAL);
     }
 
+    /**
+     * Checks if the start time is before the end time
+     *
+     * @param input A valid free time tag
+     * @return true if the start time is before the end time
+     */
+    public static boolean isValidTimeInterval(String input) {
+        String[] split = input.split("-");
+        String startString = split[0];
+        String endString = split[1];
+        int start = Integer.parseInt(startString.substring(4));
+        int end = Integer.parseInt(endString);
+        return start < end;
+    }
     /**
      * Returns true if a given string is a valid tag name.
      */

--- a/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedFreeTimeTag.java
@@ -40,7 +40,7 @@ class JsonAdaptedFreeTimeTag {
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
     public FreeTimeTag toModelType() throws IllegalValueException {
-        if (!FreeTimeTag.isValidTagName(freeTimeTagName)) {
+        if (!FreeTimeTag.isValidTagName(freeTimeTagName) || !FreeTimeTag.isValidTimeInterval(freeTimeTagName)) {
             throw new IllegalValueException(FreeTimeTag.MESSAGE_CONSTRAINTS);
         }
         return new FreeTimeTag(freeTimeTagName);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -193,7 +193,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void testParseFreeTimeTag_ValidTag() {
+    public void testParseFreeTimeTag_validTag() {
         String validTag = "Mon:0900-1700";
         try {
             FreeTimeTag freeTimeTag = ParserUtil.parseFreeTimeTag(validTag);
@@ -204,7 +204,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void testParseFreeTimeTag_InvalidTagName() {
+    public void testParseFreeTimeTag_invalidTagName() {
         String invalidTag = "Invalid Tag";
         try {
             ParserUtil.parseFreeTimeTag(invalidTag);
@@ -216,7 +216,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void testParseFreeTimeTag_InvalidTimeInterval() {
+    public void testParseFreeTimeTag_invalidTimeInterval() {
         String invalidTag = "Mon:2300-1700";
         try {
             ParserUtil.parseFreeTimeTag(invalidTag);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -14,6 +15,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.person.Telegram;
+import seedu.address.model.tag.FreeTimeTag;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
@@ -188,5 +190,40 @@ public class ParserUtilTest {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
+    }
+
+    @Test
+    public void testParseFreeTimeTag_ValidTag() {
+        String validTag = "Mon:0900-1700";
+        try {
+            FreeTimeTag freeTimeTag = ParserUtil.parseFreeTimeTag(validTag);
+            assertEquals(validTag.trim(), freeTimeTag.tagName);
+        } catch (ParseException e) {
+            fail("Valid tag should not throw ParseException");
+        }
+    }
+
+    @Test
+    public void testParseFreeTimeTag_InvalidTagName() {
+        String invalidTag = "Invalid Tag";
+        try {
+            ParserUtil.parseFreeTimeTag(invalidTag);
+            fail("Expected ParseException was not thrown");
+        } catch (ParseException e) {
+            assertEquals("Free Time Tag should be Mon-Sun:HHmm-HHmm (24hr format)",
+                    FreeTimeTag.MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    @Test
+    public void testParseFreeTimeTag_InvalidTimeInterval() {
+        String invalidTag = "Mon:2300-1700";
+        try {
+            ParserUtil.parseFreeTimeTag(invalidTag);
+            fail("Expected ParseException was not thrown");
+        } catch (ParseException e) {
+            assertEquals("Start time should be earlier than End time",
+                    FreeTimeTag.MESSAGE_INVALID_TIME_INTERVAL);
+        }
     }
 }

--- a/src/test/java/seedu/address/model/tag/FreeTimeTagTest.java
+++ b/src/test/java/seedu/address/model/tag/FreeTimeTagTest.java
@@ -7,6 +7,13 @@ import org.junit.jupiter.api.Test;
 
 public class FreeTimeTagTest {
     @Test
+    public void isValidTimeInterval() {
+        assertTrue(FreeTimeTag.isValidTimeInterval("Mon:0700-0900")); // Start > End
+        assertFalse(FreeTimeTag.isValidTimeInterval("Mon:0700-0700")); // Start == End
+        assertFalse(FreeTimeTag.isValidTimeInterval("Mon:0701-0700")); // Start < End
+    }
+
+    @Test
     public void isContained() {
         FreeTimeTag freeTimeTag = new FreeTimeTag("Mon:0700-0900");
 


### PR DESCRIPTION
Added check for time interval range of the free time tag.
The start time must be LESSER than the end time (startTime < endTime)
If time interval is invalid, it will show the following message:
1300-1200:
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/65356386/136433a0-0bf2-493a-ad00-6a3c370b73e3)
1300-1300:
![image](https://github.com/AY2324S2-CS2103T-F11-4/tp/assets/65356386/37528982-9497-42ec-809a-07e885423be7)

Also added test cases in FreeTimeTagTest.java that tests for more than, less than and equal to.